### PR TITLE
Make holmes.sh a little more portable.

### DIFF
--- a/holmes-package/src/main/resources/bin/holmes.sh
+++ b/holmes-package/src/main/resources/bin/holmes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2012-2014  Cedric Cheneau
 # 


### PR DESCRIPTION
holmes.sh should now work on Linux and FreeBSD.
